### PR TITLE
fix(payments): do not restore orders on init

### DIFF
--- a/packages/payments/order/order.android.ts
+++ b/packages/payments/order/order.android.ts
@@ -16,11 +16,17 @@ export class Order extends BaseOrder {
     this.itemId = nativeValue.getSkus().get(0) as string;
     this.receiptToken = nativeValue.getPurchaseToken();
     this.dataSignature = nativeValue.getSignature();
-    this.orderId = 'getOrderId' in nativeValue ? nativeValue.getOrderId() : null;
     this.userData = jsonObject.developerPayload;
     this.isSubscription = jsonObject.autoRenewing;
     this.orderDate = new Date(nativeValue.getPurchaseTime());
-    this.acknowledged = 'isAcknowledged' in nativeValue ? nativeValue.isAcknowledged() : null;
+    this.quantity = nativeValue.getQuantity();
+    this.acknowledged = true;
+    this.orderId = null;
+    if(nativeValue instanceof com.android.billingclient.api.Purchase) {
+      // PurchaseHistoryRecord is a subset of purchase, so let's fill the gaps here
+      this.acknowledged = nativeValue.isAcknowledged();
+      this.orderId = nativeValue.getOrderId();
+    }
     if (typeof jsonObject.purchaseState !== 'undefined') {
       // console.log('jsonObject.purchaseState:', jsonObject.purchaseState);
       switch (jsonObject.purchaseState) {

--- a/packages/payments/order/order.common.ts
+++ b/packages/payments/order/order.common.ts
@@ -15,7 +15,8 @@ export abstract class BaseOrder {
   /** Android only */
   public isSubscription: boolean;
   public dataSignature: string;
-  public acknowledged: boolean | null;
+  public acknowledged: boolean;
+  public quantity: number;
 
   constructor(nativeValue: Purchase | PurchaseHistoryRecord | SKPaymentTransaction, restored: boolean = false) {
     this.nativeValue = nativeValue;


### PR DESCRIPTION
this fixes the first few events on android but no longer emits the restored purchases on start.

Also handles Purchase/PurchaseHistory on android