### PR TITLE
fix for free phase of trial for Gooogle Play subscriptions

### DIFF
--- a/packages/payments/item/index.android.ts
+++ b/packages/payments/item/index.android.ts
@@ -19,10 +19,16 @@ export class Item extends BaseItem {
     } else if (this.type === com.android.billingclient.api.BillingClient.SkuType.SUBS) {
         const subscriptionOfferDetails = nativeValue.getSubscriptionOfferDetails().get(0)
         this.offerToken = subscriptionOfferDetails.getOfferToken();
-        const details = subscriptionOfferDetails.getPricingPhases().getPricingPhaseList().get(0);
-        this.priceAmount = details.getPriceAmountMicros() / 1000000;
-        this.priceFormatted = details.getFormattedPrice();
-        this.priceCurrencyCode = details.getPriceCurrencyCode();
+        const pricingPhaseList = subscriptionOfferDetails.getPricingPhases().getPricingPhaseList();
+        for (let i = 0; i < pricingPhaseList.size(); i++) {
+            let details = pricingPhaseList.get(pricingPhaseList.size() - 1);
+            if (details.getPriceAmountMicros() > 0) {
+                this.priceAmount = details.getPriceAmountMicros() / 1000000;
+                this.priceFormatted = details.getFormattedPrice();
+                this.priceCurrencyCode = details.getPriceCurrencyCode();
+                break;
+            }
+        }
     }
   }
 


### PR DESCRIPTION

I've identified the issue. In the latest version Google Play Billing Library, v5, if a user has never had any subscription, there will be two phases: the "free" trial with a price of $0 and the subscription price after the trial period. This update filters out the "free" phase.
Details: https://support.google.com/googleplay/android-developer/answer/12154973#zippy=%2Cfree-trials